### PR TITLE
build under melodic

### DIFF
--- a/kitti_to_rosbag/CMakeLists.txt
+++ b/kitti_to_rosbag/CMakeLists.txt
@@ -4,6 +4,8 @@ project(kitti_to_rosbag)
 find_package(catkin_simple REQUIRED)
 catkin_simple(ALL_DEPS_REQUIRED)
 
+find_package(OpenCV REQUIRED COMPONENTS core highgui imgcodecs)
+
 set(CMAKE_MACOSX_RPATH 0)
 add_definitions(-std=c++11)
 
@@ -22,17 +24,17 @@ cs_add_library(${PROJECT_NAME}
 cs_add_executable(kitti_live_node
   src/kitti_live_node.cpp
 )
-target_link_libraries(kitti_live_node ${PROJECT_NAME})
+target_link_libraries(kitti_live_node ${PROJECT_NAME} ${OpenCV_LIBRARIES})
 
 cs_add_executable(kitti_rosbag_converter
   src/kitti_rosbag_converter.cpp
 )
-target_link_libraries(kitti_rosbag_converter ${PROJECT_NAME})
+target_link_libraries(kitti_rosbag_converter ${PROJECT_NAME} ${OpenCV_LIBRARIES})
 
 cs_add_executable(tiny_disp_view
   src/tiny_disp_view.cpp
 )
-target_link_libraries(tiny_disp_view ${PROJECT_NAME})
+target_link_libraries(tiny_disp_view ${PROJECT_NAME} ${OpenCV_LIBRARIES})
 
 ##########
 # EXPORT #


### PR DESCRIPTION
Otherwise gives
```
Errors     << kitti_to_rosbag:make /home/z/catkin_ws/logs/kitti_to_rosbag/build.make.001.log
/home/z/catkin_ws/src/kitti_to_rosbag/kitti_to_rosbag/src/kitti_parser.cpp: In member function ‘std::__cxx11::string kitti::KittiParser::getFilenameForEntry(uint64_t) const’:
/home/z/catkin_ws/src/kitti_to_rosbag/kitti_to_rosbag/src/kitti_parser.cpp:574:35: warning: format ‘%llu’ expects argument of type ‘long long unsigned int’, but argument 3 has type ‘uint64_t {aka long unsigned int}’ [-Wformat=]
   sprintf(buffer, "%010llu", entry);
                                   ^
CMakeFiles/tiny_disp_view.dir/src/tiny_disp_view.cpp.o: In function `disparityCallback(boost::shared_ptr<stereo_msgs::DisparityImage_<std::allocator<void> > const> const&)':
tiny_disp_view.cpp:(.text+0x27b): undefined reference to `cv::imshow(cv::String const&, cv::_InputArray const&)'
tiny_disp_view.cpp:(.text+0x28d): undefined reference to `cv::waitKey(int)'
collect2: error: ld returned 1 exit status
make[2]: *** [/home/z/catkin_ws/devel/lib/kitti_to_rosbag/tiny_disp_view] Error 1
make[1]: *** [CMakeFiles/tiny_disp_view.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
make: *** [all] Error 2
cd /home/z/catkin_ws/build/kitti_to_rosbag; catkin build --get-env kitti_to_rosbag | catkin env -si  /usr/bin/make --jobserver-fds=6,7 -j; cd -

```